### PR TITLE
【backport】KVM: riscv: Skip CSR restore if VCPU is reloaded on the same core

### DIFF
--- a/arch/riscv/include/asm/kvm_host.h
+++ b/arch/riscv/include/asm/kvm_host.h
@@ -264,6 +264,9 @@ struct kvm_vcpu_arch {
 	/* 'static' configurations which are set only once */
 	struct kvm_vcpu_config cfg;
 
+	/* Indicates modified guest CSRs */
+	bool csr_dirty;
+
 	/* SBI steal-time accounting */
 	struct {
 		gpa_t shmem;

--- a/arch/riscv/kvm/vcpu.c
+++ b/arch/riscv/kvm/vcpu.c
@@ -25,6 +25,8 @@
 #define CREATE_TRACE_POINTS
 #include "trace.h"
 
+static DEFINE_PER_CPU(struct kvm_vcpu *, kvm_former_vcpu);
+
 const struct _kvm_stats_desc kvm_vcpu_stats_desc[] = {
 	KVM_GENERIC_VCPU_STATS(),
 	STATS_DESC_COUNTER(VCPU, ecall_exit_stat),
@@ -568,6 +570,8 @@ int kvm_arch_vcpu_ioctl_set_guest_debug(struct kvm_vcpu *vcpu,
 		vcpu->arch.cfg.hedeleg |= BIT(EXC_BREAKPOINT);
 	}
 
+	vcpu->arch.csr_dirty = true;
+
 	return 0;
 }
 
@@ -613,6 +617,21 @@ void kvm_arch_vcpu_load(struct kvm_vcpu *vcpu, int cpu)
 	struct kvm_vcpu_csr *csr = &vcpu->arch.guest_csr;
 	struct kvm_vcpu_config *cfg = &vcpu->arch.cfg;
 
+	/*
+	 * If VCPU is being reloaded on the same physical CPU and no
+	 * other KVM VCPU has run on this CPU since it was last put,
+	 * we can skip the expensive CSR and HGATP writes.
+	 *
+	 * Note: If a new CSR is added to this fast-path skip block,
+	 * make sure that 'csr_dirty' is set to true in any
+	 * ioctl (e.g., KVM_SET_ONE_REG) that modifies it.
+	 */
+	if (vcpu != __this_cpu_read(kvm_former_vcpu))
+		__this_cpu_write(kvm_former_vcpu, vcpu);
+	else if (vcpu->arch.last_exit_cpu == cpu && !vcpu->arch.csr_dirty)
+		goto csr_restore_done;
+
+	vcpu->arch.csr_dirty = false;
 	if (kvm_riscv_nacl_sync_csr_available()) {
 		nsh = nacl_shmem();
 		nacl_csr_write(nsh, CSR_VSSTATUS, csr->vsstatus);
@@ -656,6 +675,9 @@ void kvm_arch_vcpu_load(struct kvm_vcpu *vcpu, int cpu)
 
 	kvm_riscv_mmu_update_hgatp(vcpu);
 
+	kvm_riscv_vcpu_aia_load(vcpu, cpu);
+
+csr_restore_done:
 	kvm_riscv_vcpu_timer_restore(vcpu);
 
 	kvm_riscv_vcpu_host_fp_save(&vcpu->arch.host_context);
@@ -664,8 +686,6 @@ void kvm_arch_vcpu_load(struct kvm_vcpu *vcpu, int cpu)
 	kvm_riscv_vcpu_host_vector_save(&vcpu->arch.host_context);
 	kvm_riscv_vcpu_guest_vector_restore(&vcpu->arch.guest_context,
 					    vcpu->arch.isa);
-
-	kvm_riscv_vcpu_aia_load(vcpu, cpu);
 
 	kvm_make_request(KVM_REQ_STEAL_UPDATE, vcpu);
 

--- a/arch/riscv/kvm/vcpu_onereg.c
+++ b/arch/riscv/kvm/vcpu_onereg.c
@@ -627,6 +627,8 @@ static int kvm_riscv_vcpu_set_reg_csr(struct kvm_vcpu *vcpu,
 	if (rc)
 		return rc;
 
+	vcpu->arch.csr_dirty = true;
+
 	return 0;
 }
 


### PR DESCRIPTION
fixed: https://github.com/RVCK-Project/rvck/issues/358

当前 kvm_arch_vcpu_load() 会无条件恢复 guest CSRs、HGATP 和 AIA 状态。
然而，当一个 VCPU 在同一个物理 CPU 上重新加载，并且在它上次退出后没有其他 KVM VCPU 在该 CPU 上运行时，硬件 CSRs 和 AIA 寄存器仍然是有效的。

此补丁优化了 vcpu_load 路径，在满足以下条件时跳过昂贵的 CSR 和 AIA 写操作：

1、VCPU 在同一个 CPU 上重新加载（vcpu->arch.last_exit_cpu == cpu）。
2、CSRs 没有被标记为 dirty（!vcpu->arch.csr_dirty）。
3、没有其他 VCPU 使用过该 CPU（vcpu == __this_cpu_read(kvm_former_vcpu)）。

测试方法
[0001-selftest.patch](https://github.com/user-attachments/files/30820562/0001-selftest.patch)
将其临时打入内核，编译出selftest的vcpu_load_perf_test，我们可以看到在同一个cpu的reload的平均耗时从184761.01 ns降低到157247.15 ns

补丁前
/home # ./vcpu_load_perf_test.static 
=== Scenario A: Same-CPU reload ===
  Valid samples: 50000
  Average latency: 184761.01 ns
=== Scenario B: Cross-CPU migration ===
  Valid samples: 50000
  Average latency: 672092.85 ns

========== Summary ==========
Same-CPU reload:   184761.01 ns (n=50000)
Cross-CPU migrate: 672092.85 ns (n=50000)

补丁后
/home # ./vcpu_load_perf_test.static 
=== Scenario A: Same-CPU reload ===
  Valid samples: 50000
  Average latency: 157247.15 ns
=== Scenario B: Cross-CPU migration ===
  Valid samples: 50000
  Average latency: 674056.24 ns

========== Summary ==========
Same-CPU reload:   157247.15 ns (n=50000)
Cross-CPU migrate: 674056.24 ns (n=50000)
