### PR TITLE
[backport] riscv: Implement smp_cond_load8/16() with Zawrs

### DIFF
--- a/arch/riscv/include/asm/cmpxchg.h
+++ b/arch/riscv/include/asm/cmpxchg.h
@@ -367,16 +367,48 @@ static __always_inline void __cmpwait(volatile void *ptr,
 {
 	unsigned long tmp;
 
+	u32 *__ptr32b;
+	ulong __s, __val, __mask;
+
 	asm goto(ALTERNATIVE("j %l[no_zawrs]", "nop",
 			     0, RISCV_ISA_EXT_ZAWRS, 1)
 		 : : : : no_zawrs);
 
 	switch (size) {
 	case 1:
-		fallthrough;
+		__ptr32b = (u32 *)((ulong)(ptr) & ~0x3);
+		__s = ((ulong)(ptr) & 0x3) * BITS_PER_BYTE;
+		__val = val << __s;
+		__mask = 0xff << __s;
+
+		asm volatile(
+		"	lr.w	%0, %1\n"
+		"	and	%0, %0, %3\n"
+		"	xor	%0, %0, %2\n"
+		"	bnez	%0, 1f\n"
+			ZAWRS_WRS_NTO "\n"
+		"1:"
+		: "=&r" (tmp), "+A" (*(__ptr32b))
+		: "r" (__val), "r" (__mask)
+		: "memory");
+		break;
 	case 2:
-		/* RISC-V doesn't have lr instructions on byte and half-word. */
-		goto no_zawrs;
+		__ptr32b = (u32 *)((ulong)(ptr) & ~0x3);
+		__s = ((ulong)(ptr) & 0x2) * BITS_PER_BYTE;
+		__val = val << __s;
+		__mask = 0xffff << __s;
+
+		asm volatile(
+		"	lr.w	%0, %1\n"
+		"	and	%0, %0, %3\n"
+		"	xor	%0, %0, %2\n"
+		"	bnez	%0, 1f\n"
+			ZAWRS_WRS_NTO "\n"
+		"1:"
+		: "=&r" (tmp), "+A" (*(__ptr32b))
+		: "r" (__val), "r" (__mask)
+		: "memory");
+		break;
 	case 4:
 		asm volatile(
 		"	lr.w	%0, %1\n"


### PR DESCRIPTION
fixed: https://github.com/RVCK-Project/rvck/issues/367

补丁 riscv: Implement smp_cond_load8/16() with Zawrs 在 arch/riscv/include/asm/cmpxchg.h 中新增了对 byte (8-bit) 和 halfword (16-bit) 的 smp_cond_load 实现，利用 Zawrs 指令扩展 (WRS.NTO) 来优化自旋锁等待。

之前 RISC-V 内核只支持 word (32/64 位) 的 smp_cond_load，该补丁补齐了 8/16 位场景。

测试方法
[smp_cond_load_test.c](https://github.com/user-attachments/files/31262090/smp_cond_load_test.c)

测试结果
~ # insmod /home/smp_cond_load_test.ko 
[   42.385827] smp_cond_load_test: loading out-of-tree module taints kernel.
[   42.478998] cmpwait_test: module init
[   42.487520] writer: sleeping 2s before update...
[   42.490939] reader: waiting for test_byte=0x12...
[   44.519323] writer: updated test_byte=0x12
[   44.519475] reader: got test_byte match!
[   44.520820] reader: waiting for test_half=0x1234...
[   46.534158] writer: updated test_half=0x1234
[   46.534316] reader: got test_half match!

