### PR TITLE
A210 增加 GMAC 驱动

### DIFF
--- a/Documentation/devicetree/bindings/mfd/syscon.yaml
+++ b/Documentation/devicetree/bindings/mfd/syscon.yaml
@@ -69,6 +69,7 @@ properties:
               - rockchip,rk3588-qos
               - rockchip,rv1126-qos
               - starfive,jh7100-sysmain
+              - zhihe,a210-gmac-syscon
 
           - const: syscon
 

--- a/Documentation/devicetree/bindings/net/snps,dwmac.yaml
+++ b/Documentation/devicetree/bindings/net/snps,dwmac.yaml
@@ -97,6 +97,7 @@ properties:
         - snps,dwxgmac-2.10
         - starfive,jh7110-dwmac
         - thead,th1520-dwmac
+        - zhihe,a210-dwmac
 
   reg:
     minItems: 1

--- a/Documentation/devicetree/bindings/net/zhihe,a210-dwmac.yaml
+++ b/Documentation/devicetree/bindings/net/zhihe,a210-dwmac.yaml
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/net/zhihe,a210-dwmac.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: ZhiHe A210 DWMAC Ethernet controller
+
+maintainers:
+  - Zhiguo Zhu <zhiguo.zhu@linux.alibaba.com>
+
+description:
+  The ZhiHe A210 integrates a Synopsys DesignWare MAC (dwmac-5.20) with
+  an SoC-specific glue layer for clock gating, reset sequencing, interface
+  selection and link-speed configuration.
+
+select:
+  properties:
+    compatible:
+      contains:
+        const: zhihe,a210-dwmac
+  required:
+    - compatible
+
+properties:
+  compatible:
+    items:
+      - const: zhihe,a210-dwmac
+      - const: snps,dwmac-5.20
+
+  reg:
+    maxItems: 1
+
+  reg-names:
+    const: gmac
+
+  interrupts:
+    maxItems: 1
+
+  interrupt-names:
+    const: macirq
+
+  clocks:
+    items:
+      - description: GMAC main clock
+      - description: GMAC AHB peripheral clock
+      - description: X2H AXI clock
+      - description: X2H AHB clock
+
+  clock-names:
+    items:
+      - const: stmmaceth
+      - const: pclk
+      - const: x2h_aclk
+      - const: x2h_hclk
+
+  resets:
+    items:
+      - description: GMAC reset
+      - description: X2H reset
+
+  reset-names:
+    items:
+      - const: stmmaceth
+      - const: ahb
+
+  zhihe,gmacsys:
+    $ref: /schemas/types.yaml#/definitions/phandle
+    description:
+      Phandle to the syscon node controlling GMAC interface mode and
+      link speed.
+
+  rx-clk-delay:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: RGMII RX clock delay setting.
+
+  tx-clk-delay:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: RGMII TX clock delay setting.
+
+  snps,pbl:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: Programmable burst length.
+    enum: [1, 2, 4, 8, 16, 32]
+
+  snps,fixed-burst:
+    type: boolean
+    description: Program the DMA to use fixed burst mode.
+
+  snps,tso:
+    type: boolean
+    description: Enable TCP segmentation offload.
+
+  snps,axi-config:
+    $ref: /schemas/types.yaml#/definitions/phandle
+    description: Phandle to the AXI bus mode configuration node.
+
+  mdio:
+    $ref: mdio.yaml#
+    unevaluatedProperties: false
+
+    properties:
+      compatible:
+        const: snps,dwmac-mdio
+
+    required:
+      - compatible
+
+required:
+  - compatible
+  - reg
+  - clocks
+  - clock-names
+  - interrupts
+  - interrupt-names
+  - phy-mode
+  - resets
+  - reset-names
+  - zhihe,gmacsys
+
+allOf:
+  - $ref: snps,dwmac.yaml#
+
+unevaluatedProperties: false
+
+examples:
+  - |
+    ethernet@2100000 {
+        compatible = "zhihe,a210-dwmac", "snps,dwmac-5.20";
+        reg = <0x02100000 0x10000>;
+        reg-names = "gmac";
+        interrupts = <277>;
+        interrupt-names = "macirq";
+        phy-mode = "rgmii-id";
+        clocks = <&clk 0>, <&clk 1>, <&clk 2>, <&clk 3>;
+        clock-names = "stmmaceth", "pclk", "x2h_aclk", "x2h_hclk";
+        resets = <&rst 0>, <&rst 1>;
+        reset-names = "stmmaceth", "ahb";
+        snps,pbl = <32>;
+        snps,fixed-burst;
+        zhihe,gmacsys = <&gmac0_sys>;
+        phy-handle = <&phy0>;
+
+        mdio {
+            compatible = "snps,dwmac-mdio";
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            phy0: ethernet-phy@0 {
+                reg = <0>;
+            };
+        };
+    };

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -23999,6 +23999,13 @@ L:	linux-kernel@vger.kernel.org
 S:	Maintained
 F:	arch/x86/kernel/cpu/zhaoxin.c
 
+ZHIHE A210 DWMAC DRIVER
+M:	Zhiguo Zhu <zhiguo.zhu@linux.alibaba.com>
+L:	netdev@vger.kernel.org
+S:	Maintained
+F:	Documentation/devicetree/bindings/net/zhihe,a210-dwmac.yaml
+F:	drivers/net/ethernet/stmicro/stmmac/dwmac-zhihe.c
+
 ZONEFS FILESYSTEM
 M:	Damien Le Moal <dlemoal@kernel.org>
 M:	Naohiro Aota <naohiro.aota@wdc.com>

--- a/arch/riscv/boot/dts/zhihe/a210-dev.dts
+++ b/arch/riscv/boot/dts/zhihe/a210-dev.dts
@@ -8,6 +8,7 @@
 	compatible = "zhihe,a210-dev", "zhihe,a210";
 
 	aliases {
+		ethernet0 = &gmac0;
 		mmc0 = &emmc;
 		serial0 = &uart0;
 		serial1 = &uart1;
@@ -19,6 +20,20 @@
 		serial7 = &uart7;
 		serial8 = &uart8;
 		serial9 = &uart9;
+	};
+};
+
+&gmac0 {
+	phy-mode = "rgmii-id";
+	status = "okay";
+	rx-clk-delay = <0x00>;
+	tx-clk-delay = <0x00>;
+	phy-handle = <&phy0>;
+};
+
+&mdio0 {
+	phy0: ethernet-phy@0 {
+		reg = <0x0>;
 	};
 };
 

--- a/arch/riscv/boot/dts/zhihe/a210-evb.dts
+++ b/arch/riscv/boot/dts/zhihe/a210-evb.dts
@@ -8,6 +8,8 @@
 	compatible = "zhihe,a210-evb", "zhihe,a210";
 
 	aliases {
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
 		mmc0 = &emmc;
 		serial0 = &uart0;
 		serial1 = &uart1;
@@ -19,6 +21,32 @@
 		serial7 = &uart7;
 		serial8 = &uart8;
 		serial9 = &uart9;
+	};
+};
+
+&gmac0 {
+	phy-mode = "rgmii-id";
+	status = "okay";
+	rx-clk-delay = <0x00>;
+	tx-clk-delay = <0x00>;
+	phy-handle = <&phy0>;
+};
+
+&mdio0 {
+	phy0: ethernet-phy@0 {
+		reg = <0x0>;
+	};
+};
+
+&gmac1 {
+	phy-mode = "rgmii-id";
+	status = "disabled";
+	phy-handle = <&phy1>;
+};
+
+&mdio1 {
+	phy1: ethernet-phy@0 {
+		reg = <0x0>;
 	};
 };
 

--- a/arch/riscv/boot/dts/zhihe/a210.dtsi
+++ b/arch/riscv/boot/dts/zhihe/a210.dtsi
@@ -587,6 +587,12 @@
 		};
 	};
 
+	stmmac_axi_setup: stmmac-axi-config {
+		snps,wr_osr_lmt = <7>;
+		snps,rd_osr_lmt = <7>;
+		snps,blen = <16 8 4 0 0 0 0>;
+	};
+
 	soc {
 		compatible = "simple-bus";
 		#address-cells = <2>;
@@ -924,6 +930,74 @@
 					 <&clk_peri PERI3_EMMC_HCLK_EN>;
 			clock-names = "core", "bus";
 			clk-delay-mmc-hs400 = <24>;
+		};
+
+		gmac0_sys: syscon@210f000 {
+			compatible = "zhihe,a210-gmac-syscon", "syscon";
+			reg = <0x00 0x0210f000 0x0 0x20>;
+		};
+
+		gmac1_sys: syscon@211f000 {
+			compatible = "zhihe,a210-gmac-syscon", "syscon";
+			reg = <0x00 0x0211f000 0x0 0x20>;
+		};
+
+		gmac0: ethernet@2100000 {
+			compatible = "zhihe,a210-dwmac", "snps,dwmac-5.20";
+			reg = <0x00 0x02100000 0x0 0x10000>;
+			reg-names = "gmac";
+			interrupt-parent = <&intc>;
+			interrupts = <277>;
+			interrupt-names = "macirq";
+			clocks = <&clk_peri PERI1_GMAC0_ACLK_EN>,
+				 <&clk_peri PERI1_GMAC0_HCLK_EN>,
+				 <&clk_peri PERI1_X2H_GMAC0_ACLK_EN>,
+				 <&clk_peri PERI1_X2H_GMAC0_HCLK_EN>;
+			clock-names = "stmmaceth", "pclk", "x2h_aclk", "x2h_hclk";
+			resets = <&rst_peri1 PERI1_GMAC0_RST>,
+				 <&rst_peri1 PERI1_GMAC0_X2H_RST>;
+			reset-names = "stmmaceth", "ahb";
+			snps,pbl = <32>;
+			snps,fixed-burst;
+			snps,axi-config = <&stmmac_axi_setup>;
+			snps,tso;
+			zhihe,gmacsys = <&gmac0_sys>;
+			status = "disabled";
+
+			mdio0: mdio {
+				compatible = "snps,dwmac-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
+		};
+
+		gmac1: ethernet@2110000 {
+			compatible = "zhihe,a210-dwmac", "snps,dwmac-5.20";
+			reg = <0x00 0x02110000 0x0 0x10000>;
+			reg-names = "gmac";
+			interrupt-parent = <&intc>;
+			interrupts = <288>;
+			interrupt-names = "macirq";
+			clocks = <&clk_peri PERI1_GMAC1_ACLK_EN>,
+				 <&clk_peri PERI1_GMAC1_HCLK_EN>,
+				 <&clk_peri PERI1_X2H_GMAC1_ACLK_EN>,
+				 <&clk_peri PERI1_X2H_GMAC1_HCLK_EN>;
+			clock-names = "stmmaceth", "pclk", "x2h_aclk", "x2h_hclk";
+			resets = <&rst_peri1 PERI1_GMAC1_RST>,
+				 <&rst_peri1 PERI1_GMAC1_X2H_RST>;
+			reset-names = "stmmaceth", "ahb";
+			snps,pbl = <32>;
+			snps,fixed-burst;
+			snps,axi-config = <&stmmac_axi_setup>;
+			snps,tso;
+			zhihe,gmacsys = <&gmac1_sys>;
+			status = "disabled";
+
+			mdio1: mdio {
+				compatible = "snps,dwmac-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+			};
 		};
 
 	};

--- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
+++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
@@ -236,6 +236,18 @@ config DWMAC_THEAD
 	  the stmmac device driver. This driver is used for XuanTie TH1520
 	  ethernet controller.
 
+config DWMAC_ZHIHE
+	tristate "ZhiHe dwmac support"
+	depends on OF && (ARCH_ZHIHE || COMPILE_TEST)
+	default STMMAC_ETH if ARCH_ZHIHE
+	select MFD_SYSCON
+	help
+	  Support for the Synopsys DesignWare MAC Ethernet controller
+	  found on ZhiHe SoCs, through a platform glue layer for the
+	  stmmac driver. It handles the clock and reset configuration
+	  specific to the ZhiHe A210 platform. Say Y or M here if you
+	  are building a kernel for a ZhiHe A210 based board.
+
 config DWMAC_IMX8
 	tristate "NXP IMX8 DWMAC support"
 	default ARCH_MXC

--- a/drivers/net/ethernet/stmicro/stmmac/Makefile
+++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
@@ -30,6 +30,7 @@ obj-$(CONFIG_DWMAC_STM32)	+= dwmac-stm32.o
 obj-$(CONFIG_DWMAC_SUNXI)	+= dwmac-sunxi.o
 obj-$(CONFIG_DWMAC_SUN8I)	+= dwmac-sun8i.o
 obj-$(CONFIG_DWMAC_THEAD)	+= dwmac-thead.o
+obj-$(CONFIG_DWMAC_ZHIHE)	+= dwmac-zhihe.o
 obj-$(CONFIG_DWMAC_DWC_QOS_ETH)	+= dwmac-dwc-qos-eth.o
 obj-$(CONFIG_DWMAC_INTEL_PLAT)	+= dwmac-intel-plat.o
 obj-$(CONFIG_DWMAC_GENERIC)	+= dwmac-generic.o

--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-zhihe.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-zhihe.c
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2025 Zhihe Computing Limited.
+ */
+
+#include <linux/bitfield.h>
+#include <linux/clk.h>
+#include <linux/mfd/syscon.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/phy.h>
+#include <linux/platform_device.h>
+#include <linux/regmap.h>
+#include <linux/reset.h>
+
+#include "stmmac_platform.h"
+
+#define GMAC_CLKCTRL			0x00
+#define GMAC_CTRL			0x04
+
+#define GMAC_CLKCTRL_EN_ALL		GENMASK(4, 0)
+#define GMAC_CLKCTRL_SPEED_MASK		GENMASK(9, 8)
+#define GMAC_CLKCTRL_SPEED_1G		FIELD_PREP(GMAC_CLKCTRL_SPEED_MASK, 0)
+#define GMAC_CLKCTRL_SPEED_10M		FIELD_PREP(GMAC_CLKCTRL_SPEED_MASK, 2)
+#define GMAC_CLKCTRL_SPEED_100M		FIELD_PREP(GMAC_CLKCTRL_SPEED_MASK, 3)
+
+#define GMAC_CTRL_INTF_MASK		GENMASK(3, 0)
+#define GMAC_CTRL_INTF_RGMII		FIELD_PREP(GMAC_CTRL_INTF_MASK, 1)
+#define GMAC_CTRL_INTF_RMII		FIELD_PREP(GMAC_CTRL_INTF_MASK, 4)
+
+#define ZHIHE_DWMAC_NUM_CLKS		4
+
+static const char * const zhihe_dwmac_clk_names[ZHIHE_DWMAC_NUM_CLKS] = {
+	"stmmaceth",
+	"pclk",
+	"x2h_aclk",
+	"x2h_hclk",
+};
+
+struct zhihe_dwmac {
+	struct device *dev;
+	struct regmap *sys_regmap;
+	struct clk_bulk_data clks[ZHIHE_DWMAC_NUM_CLKS];
+	struct plat_stmmacenet_data *plat_dat;
+};
+
+static int zhihe_dwmac_set_speed(struct zhihe_dwmac *dwmac,
+				 unsigned int speed)
+{
+	phy_interface_t interface = dwmac->plat_dat->phy_interface;
+	u32 interface_val, speed_val;
+	int ret;
+
+	switch (speed) {
+	case SPEED_10:
+		speed_val = GMAC_CLKCTRL_SPEED_10M;
+		break;
+	case SPEED_100:
+		speed_val = GMAC_CLKCTRL_SPEED_100M;
+		break;
+	case SPEED_1000:
+		speed_val = GMAC_CLKCTRL_SPEED_1G;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	switch (interface) {
+	case PHY_INTERFACE_MODE_RGMII:
+	case PHY_INTERFACE_MODE_RGMII_ID:
+	case PHY_INTERFACE_MODE_RGMII_TXID:
+	case PHY_INTERFACE_MODE_RGMII_RXID:
+		interface_val = GMAC_CTRL_INTF_RGMII;
+		break;
+	case PHY_INTERFACE_MODE_RMII:
+		interface_val = GMAC_CTRL_INTF_RMII;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = regmap_update_bits(dwmac->sys_regmap, GMAC_CLKCTRL,
+				 GMAC_CLKCTRL_SPEED_MASK, speed_val);
+	if (ret)
+		return ret;
+
+	return regmap_update_bits(dwmac->sys_regmap, GMAC_CTRL,
+				  GMAC_CTRL_INTF_MASK, interface_val);
+}
+
+static int zhihe_dwmac_clkctrl_enable(struct zhihe_dwmac *dwmac,
+				      bool enable)
+{
+	return regmap_update_bits(dwmac->sys_regmap, GMAC_CLKCTRL,
+				  GMAC_CLKCTRL_EN_ALL,
+				  enable ? GMAC_CLKCTRL_EN_ALL : 0);
+}
+
+static int zhihe_dwmac_get_resources(struct zhihe_dwmac *dwmac)
+{
+	struct device *dev = dwmac->dev;
+	int i, ret;
+
+	for (i = 0; i < ZHIHE_DWMAC_NUM_CLKS; i++)
+		dwmac->clks[i].id = zhihe_dwmac_clk_names[i];
+
+	ret = devm_clk_bulk_get(dev, ZHIHE_DWMAC_NUM_CLKS, dwmac->clks);
+	if (ret)
+		return dev_err_probe(dev, ret, "failed to get clocks\n");
+
+	dwmac->sys_regmap =
+		syscon_regmap_lookup_by_phandle(dev->of_node, "zhihe,gmacsys");
+	if (IS_ERR(dwmac->sys_regmap))
+		return dev_err_probe(dev, PTR_ERR(dwmac->sys_regmap),
+				     "failed to get GMAC syscon regmap\n");
+
+	return 0;
+}
+
+static int zhihe_dwmac_peri_clk_enable(struct zhihe_dwmac *dwmac)
+{
+	int ret;
+
+	ret = clk_bulk_prepare_enable(ZHIHE_DWMAC_NUM_CLKS, dwmac->clks);
+	if (ret)
+		dev_err(dwmac->dev, "failed to enable clocks: %d\n", ret);
+
+	return ret;
+}
+
+static void zhihe_dwmac_peri_clk_disable(void *data)
+{
+	struct zhihe_dwmac *dwmac = data;
+
+	clk_bulk_disable_unprepare(ZHIHE_DWMAC_NUM_CLKS, dwmac->clks);
+}
+
+static void zhihe_dwmac_fix_mac_speed(void *priv, unsigned int speed,
+				      unsigned int mode)
+{
+	struct zhihe_dwmac *dwmac = priv;
+	int ret;
+
+	ret = zhihe_dwmac_set_speed(dwmac, speed);
+	if (ret)
+		dev_err(dwmac->dev, "failed to configure link speed %u: %d\n",
+			speed, ret);
+}
+
+static int zhihe_dwmac_clks_config(void *priv, bool enabled)
+{
+	struct zhihe_dwmac *dwmac = priv;
+	int err, ret = 0;
+
+	if (enabled) {
+		ret = zhihe_dwmac_peri_clk_enable(dwmac);
+		if (ret)
+			return ret;
+
+		ret = reset_control_deassert(dwmac->plat_dat->stmmac_rst);
+		if (ret)
+			goto err_assert_stmmac;
+
+		ret = reset_control_deassert(dwmac->plat_dat->stmmac_ahb_rst);
+		if (ret)
+			goto err_assert_ahb;
+
+		ret = zhihe_dwmac_clkctrl_enable(dwmac, true);
+		if (ret)
+			goto err_assert_ahb;
+
+		return 0;
+	}
+
+	ret = zhihe_dwmac_clkctrl_enable(dwmac, false);
+	if (ret)
+		dev_err(dwmac->dev, "failed to disable internal clocks: %d\n",
+			ret);
+
+	err = reset_control_assert(dwmac->plat_dat->stmmac_ahb_rst);
+	if (err) {
+		dev_err(dwmac->dev, "failed to assert AHB reset: %d\n", err);
+		if (!ret)
+			ret = err;
+	}
+
+	err = reset_control_assert(dwmac->plat_dat->stmmac_rst);
+	if (err) {
+		dev_err(dwmac->dev, "failed to assert GMAC reset: %d\n", err);
+		if (!ret)
+			ret = err;
+	}
+
+	zhihe_dwmac_peri_clk_disable(dwmac);
+
+	return ret;
+
+err_assert_ahb:
+	reset_control_assert(dwmac->plat_dat->stmmac_ahb_rst);
+err_assert_stmmac:
+	reset_control_assert(dwmac->plat_dat->stmmac_rst);
+	zhihe_dwmac_peri_clk_disable(dwmac);
+	dev_err(dwmac->dev, "failed to enable GMAC resources: %d\n", ret);
+
+	return ret;
+}
+
+static int zhihe_dwmac_probe(struct platform_device *pdev)
+{
+	struct plat_stmmacenet_data *plat_dat;
+	struct stmmac_resources stmmac_res;
+	struct device *dev = &pdev->dev;
+	struct zhihe_dwmac *dwmac;
+	int ret;
+
+	ret = stmmac_get_platform_resources(pdev, &stmmac_res);
+	if (ret)
+		return dev_err_probe(dev, ret,
+				     "failed to get platform resources\n");
+
+	plat_dat = devm_stmmac_probe_config_dt(pdev, stmmac_res.mac);
+	if (IS_ERR(plat_dat))
+		return dev_err_probe(dev, PTR_ERR(plat_dat),
+				     "failed to parse device tree\n");
+
+	dwmac = devm_kzalloc(dev, sizeof(*dwmac), GFP_KERNEL);
+	if (!dwmac)
+		return -ENOMEM;
+
+	dwmac->dev = dev;
+	dwmac->plat_dat = plat_dat;
+
+	plat_dat->bsp_priv = dwmac;
+	plat_dat->fix_mac_speed = zhihe_dwmac_fix_mac_speed;
+	plat_dat->clks_config = zhihe_dwmac_clks_config;
+	plat_dat->host_dma_width = 32;
+
+	ret = zhihe_dwmac_get_resources(dwmac);
+	if (ret)
+		return ret;
+
+	ret = zhihe_dwmac_peri_clk_enable(dwmac);
+	if (ret)
+		return ret;
+
+	ret = devm_add_action_or_reset(dev, zhihe_dwmac_peri_clk_disable,
+				       dwmac);
+	if (ret)
+		return ret;
+
+	return stmmac_dvr_probe(dev, plat_dat, &stmmac_res);
+}
+
+static const struct of_device_id zhihe_dwmac_match[] = {
+	{ .compatible = "zhihe,a210-dwmac" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, zhihe_dwmac_match);
+
+static struct platform_driver zhihe_dwmac_driver = {
+	.probe = zhihe_dwmac_probe,
+	.remove_new = stmmac_pltfr_remove,
+	.driver = {
+		.name = "zhihe-dwmac",
+		.pm = &stmmac_pltfr_pm_ops,
+		.of_match_table = zhihe_dwmac_match,
+	},
+};
+module_platform_driver(zhihe_dwmac_driver);
+
+MODULE_AUTHOR("Zhiguo Zhu <zhiguo.zhu@linux.alibaba.com>");
+MODULE_DESCRIPTION("ZhiHe A210 DWMAC glue driver");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
  为 A210 增加 GMAC 以太网支持。

  主要内容：
  - 增加 A210 GMAC syscon binding
  - 增加 A210 DWMAC binding
  - 增加 A210 DWMAC glue layer 驱动
  - 补充 A210 DTS 中的 Ethernet controller 节点及板级使能

  验证：
  - kernel build 通过
  - checkpatch 通过
  - kunit test 通过

  fixed #370