### PR TITLE
ZhiHe A210: add peripheral support (GPIO/timers/I2C/SPI/DMA)

### DIFF
--- a/Documentation/devicetree/bindings/dma/snps,dw-axi-dmac.yaml
+++ b/Documentation/devicetree/bindings/dma/snps,dw-axi-dmac.yaml
@@ -14,6 +14,27 @@ description:
 
 allOf:
   - $ref: dma-controller.yaml#
+  - if:
+      properties:
+        compatible:
+          contains:
+            const: zhihe,a210-axi-dma
+    then:
+      properties:
+        dma-channels:
+          maximum: 16
+        snps,priority:
+          maxItems: 16
+        snps,block-size:
+          maxItems: 16
+    else:
+      properties:
+        dma-channels:
+          maximum: 8
+        snps,priority:
+          maxItems: 8
+        snps,block-size:
+          maxItems: 8
 
 properties:
   compatible:
@@ -21,6 +42,7 @@ properties:
       - snps,axi-dma-1.01a
       - intel,kmb-axi-dma
       - starfive,jh7110-axi-dma
+      - zhihe,a210-axi-dma
 
   reg:
     minItems: 1
@@ -56,7 +78,7 @@ properties:
 
   dma-channels:
     minimum: 1
-    maximum: 8
+    maximum: 16
 
   resets:
     minItems: 1
@@ -80,14 +102,14 @@ properties:
       Channel priority specifier associated with the DMA channels.
     $ref: /schemas/types.yaml#/definitions/uint32-array
     minItems: 1
-    maxItems: 8
+    maxItems: 16
 
   snps,block-size:
     description: |
       Channel block size specifier associated with the DMA channels.
     $ref: /schemas/types.yaml#/definitions/uint32-array
     minItems: 1
-    maxItems: 8
+    maxItems: 16
 
   snps,axi-max-burst-len:
     description: |
@@ -117,6 +139,7 @@ if:
       contains:
         enum:
           - starfive,jh7110-axi-dma
+          - zhihe,a210-axi-dma
 then:
   properties:
     resets:

--- a/arch/riscv/boot/dts/zhihe/a210-evb.dts
+++ b/arch/riscv/boot/dts/zhihe/a210-evb.dts
@@ -527,3 +527,7 @@
 };
 
 /delete-node/ &power;
+
+&peri3_gpio {
+	status = "disabled";
+};

--- a/arch/riscv/boot/dts/zhihe/a210.dtsi
+++ b/arch/riscv/boot/dts/zhihe/a210.dtsi
@@ -909,6 +909,43 @@
 			resets = <&rst_peri0 PERI0_WDT0_PRST>;
 		};
 
+		dmac0: dma-controller@520000 {
+			compatible = "zhihe,a210-axi-dma";
+			reg = <0x00 0x00520000 0x0 0x4000>;
+			interrupt-parent = <&intc>;
+			interrupts = <264>;
+			clocks = <&clk_peri PERI3_DMAC_ACLK_EN>, <&clk_peri PERI3_DMAC_HCLK_EN>;
+			clock-names = "core-clk", "cfgr-clk";
+			resets = <&rst_peri3 PERI3_DMAC_ARST>, <&rst_peri3 PERI3_DMAC_HRST>;
+			#dma-cells = <1>;
+			dma-channels = <16>;
+			snps,block-size = <65536 65536 65536 65536
+					    65536 65536 65536 65536
+					    65536 65536 65536 65536
+					    65536 65536 65536 65536>;
+			snps,priority = <0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0>;
+			snps,dma-masters = <1>;
+			snps,data-width = <4>;
+			snps,axi-max-burst-len = <4>;
+		};
+
+		dmac1: dma-controller@27540000 {
+			compatible = "zhihe,a210-axi-dma";
+			reg = <0x00 0x27540000 0x0 0x4000>;
+			interrupt-parent = <&intc>;
+			interrupts = <259>;
+			clocks = <&clk_peri TEE_DMAC_CLKEN>, <&clk_peri TEE_DMAC_CLKEN>;
+			clock-names = "core-clk", "cfgr-clk";
+			resets = <&rst_tee TEE_DMAC_ARST>, <&rst_tee TEE_DMAC_HRST>;
+			#dma-cells = <1>;
+			dma-channels = <4>;
+			snps,block-size = <65536 65536 65536 65536>;
+			snps,priority = <0 0 0 0>;
+			snps,dma-masters = <1>;
+			snps,data-width = <4>;
+			snps,axi-max-burst-len = <16>;
+		};
+
 		uart0: serial@2014000 {
 			compatible = "snps,dw-apb-uart";
 			reg = <0x00 0x02014000 0x0 0x400>;

--- a/arch/riscv/boot/dts/zhihe/a210.dtsi
+++ b/arch/riscv/boot/dts/zhihe/a210.dtsi
@@ -1334,6 +1334,94 @@
 			};
 		};
 
+		timer0: timer@303000 {
+			compatible = "snps,dw-apb-timer";
+			reg = <0x00 0x00303000 0x0 0x14>;
+			interrupt-parent = <&intc>;
+			interrupts = <313>;
+			clocks = <&clk_peri PERI0_TIMER0_CCLK_EN>,
+				 <&clk_peri PERI0_TIMER0_PCLK_EN>;
+			clock-names = "timer", "pclk";
+			resets = <&rst_peri0 PERI0_TIMER0_RST>;
+		};
+
+		timer1: timer@303014 {
+			compatible = "snps,dw-apb-timer";
+			reg = <0x00 0x00303014 0x0 0x14>;
+			interrupt-parent = <&intc>;
+			interrupts = <314>;
+			clocks = <&clk_peri PERI0_TIMER0_CCLK_EN>,
+				 <&clk_peri PERI0_TIMER0_PCLK_EN>;
+			clock-names = "timer", "pclk";
+			resets = <&rst_peri0 PERI0_TIMER0_RST>;
+		};
+
+		timer2: timer@303028 {
+			compatible = "snps,dw-apb-timer";
+			reg = <0x00 0x00303028 0x0 0x14>;
+			interrupt-parent = <&intc>;
+			interrupts = <315>;
+			clocks = <&clk_peri PERI0_TIMER0_CCLK_EN>,
+				 <&clk_peri PERI0_TIMER0_PCLK_EN>;
+			clock-names = "timer", "pclk";
+			resets = <&rst_peri0 PERI0_TIMER0_RST>;
+		};
+
+		timer3: timer@30303c {
+			compatible = "snps,dw-apb-timer";
+			reg = <0x00 0x0030303c 0x0 0x14>;
+			interrupt-parent = <&intc>;
+			interrupts = <316>;
+			clocks = <&clk_peri PERI0_TIMER0_CCLK_EN>,
+				 <&clk_peri PERI0_TIMER0_PCLK_EN>;
+			clock-names = "timer", "pclk";
+			resets = <&rst_peri0 PERI0_TIMER0_RST>;
+		};
+
+		timer4: timer@304000 {
+			compatible = "snps,dw-apb-timer";
+			reg = <0x00 0x00304000 0x0 0x14>;
+			interrupt-parent = <&intc>;
+			interrupts = <317>;
+			clocks = <&clk_peri PERI0_TIMER1_CCLK_EN>,
+				 <&clk_peri PERI0_TIMER1_PCLK_EN>;
+			clock-names = "timer", "pclk";
+			resets = <&rst_peri0 PERI0_TIMER1_RST>;
+		};
+
+		timer5: timer@304014 {
+			compatible = "snps,dw-apb-timer";
+			reg = <0x00 0x00304014 0x0 0x14>;
+			interrupt-parent = <&intc>;
+			interrupts = <318>;
+			clocks = <&clk_peri PERI0_TIMER1_CCLK_EN>,
+				 <&clk_peri PERI0_TIMER1_PCLK_EN>;
+			clock-names = "timer", "pclk";
+			resets = <&rst_peri0 PERI0_TIMER1_RST>;
+		};
+
+		timer6: timer@304028 {
+			compatible = "snps,dw-apb-timer";
+			reg = <0x00 0x00304028 0x0 0x14>;
+			interrupt-parent = <&intc>;
+			interrupts = <319>;
+			clocks = <&clk_peri PERI0_TIMER1_CCLK_EN>,
+				 <&clk_peri PERI0_TIMER1_PCLK_EN>;
+			clock-names = "timer", "pclk";
+			resets = <&rst_peri0 PERI0_TIMER1_RST>;
+		};
+
+		timer7: timer@30403c {
+			compatible = "snps,dw-apb-timer";
+			reg = <0x00 0x0030403c 0x0 0x14>;
+			interrupt-parent = <&intc>;
+			interrupts = <320>;
+			clocks = <&clk_peri PERI0_TIMER1_CCLK_EN>,
+				 <&clk_peri PERI0_TIMER1_PCLK_EN>;
+			clock-names = "timer", "pclk";
+			resets = <&rst_peri0 PERI0_TIMER1_RST>;
+		};
+
 		mbox_920: mailbox@321000 {
 			compatible = "zhihe,a210-mailbox-v2";
 			reg = <0x00 0x00321000 0x0 0x1000>,

--- a/arch/riscv/boot/dts/zhihe/a210.dtsi
+++ b/arch/riscv/boot/dts/zhihe/a210.dtsi
@@ -1422,6 +1422,123 @@
 			resets = <&rst_peri0 PERI0_TIMER1_RST>;
 		};
 
+		i2c0: i2c@2020000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x02020000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <293>;
+			clocks = <&clk_peri PERI1_I2C0_IC_CLK_EN>,
+				 <&clk_peri PERI1_I2C0_PCLK_EN>;
+			clock-names = "ref", "pclk";
+			resets = <&rst_peri1 PERI1_I2C0_RST>;
+			dmas = <&dmac0 21>, <&dmac0 20>;
+			dma-names = "tx", "rx";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1: i2c@2021000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x02021000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <294>;
+			clocks = <&clk_peri PERI1_I2C1_IC_CLK_EN>,
+				 <&clk_peri PERI1_I2C1_PCLK_EN>;
+			clock-names = "ref", "pclk";
+			resets = <&rst_peri1 PERI1_I2C1_RST>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c2: i2c@2022000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x02022000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <295>;
+			clocks = <&clk_peri PERI1_I2C2_IC_CLK_EN>,
+				 <&clk_peri PERI1_I2C2_PCLK_EN>;
+			clock-names = "ref", "pclk";
+			resets = <&rst_peri1 PERI1_I2C2_RST>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c3: i2c@8415000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x08415000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <296>;
+			clocks = <&clk_peri PERI2_I2C3_IC_CLK_EN>,
+				 <&clk_peri PERI2_I2C3_PCLK_EN>;
+			clock-names = "ref", "pclk";
+			resets = <&rst_peri2 PERI2_I2C3_RST>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c4: i2c@8416000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x08416000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <297>;
+			clocks = <&clk_peri PERI2_I2C4_IC_CLK_EN>,
+				 <&clk_peri PERI2_I2C4_PCLK_EN>;
+			clock-names = "ref", "pclk";
+			resets = <&rst_peri2 PERI2_I2C4_RST>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c5: i2c@8417000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x08417000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <298>;
+			clocks = <&clk_peri PERI2_I2C5_IC_CLK_EN>,
+				 <&clk_peri PERI2_I2C5_PCLK_EN>;
+			clock-names = "ref", "pclk";
+			resets = <&rst_peri2 PERI2_I2C5_RST>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c6: i2c@8418000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x08418000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <299>;
+			clocks = <&clk_peri PERI2_I2C6_IC_CLK_EN>,
+				 <&clk_peri PERI2_I2C6_PCLK_EN>;
+			clock-names = "ref", "pclk";
+			resets = <&rst_peri2 PERI2_I2C6_RST>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c7: i2c@8419000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x08419000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <300>;
+			clocks = <&clk_peri PERI2_I2C7_IC_CLK_EN>,
+				 <&clk_peri PERI2_I2C7_PCLK_EN>;
+			clock-names = "ref", "pclk";
+			resets = <&rst_peri2 PERI2_I2C7_RST>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		aoi2c1: i2c@30891000 {
+			compatible = "snps,designware-i2c";
+			reg = <0x00 0x30891000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <20>;
+			clocks = <&aon_110m>;
+			clock-names = "ref";
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		mbox_920: mailbox@321000 {
 			compatible = "zhihe,a210-mailbox-v2";
 			reg = <0x00 0x00321000 0x0 0x1000>,

--- a/arch/riscv/boot/dts/zhihe/a210.dtsi
+++ b/arch/riscv/boot/dts/zhihe/a210.dtsi
@@ -1066,6 +1066,40 @@
 			reg-io-width = <4>;
 		};
 
+		spi0: spi@2023000 {
+			compatible = "snps,dw-apb-ssi";
+			reg = <0x00 0x02023000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <310>;
+			clocks = <&clk_peri PERI1_SPI0_SSI_CLK_EN>,
+				 <&clk_peri PERI1_SPI0_PCLK_EN>;
+			clock-names = "ssi_clk", "pclk";
+			resets = <&rst_peri1 PERI1_SPI0_RST>;
+			reset-names = "spi";
+			dmas = <&dmac0 9>, <&dmac0 8>;
+			dma-names = "tx", "rx";
+			num-cs = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi1: spi@8413000 {
+			compatible = "snps,dw-apb-ssi";
+			reg = <0x00 0x08413000 0x0 0x1000>;
+			interrupt-parent = <&intc>;
+			interrupts = <311>;
+			clocks = <&clk_peri PERI2_SPI1_SSI_CLK_EN>,
+				 <&clk_peri PERI2_SPI1_PCLK_EN>;
+			clock-names = "ssi_clk", "pclk";
+			resets = <&rst_peri2 PERI2_SPI1_RST>;
+			reset-names = "spi";
+			dmas = <&dmac0 62>, <&dmac0 61>;
+			dma-names = "tx", "rx";
+			num-cs = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
 		emmc: mmc@500000 {
 			compatible = "zhihe,a210-dwcmshc";
 			reg = <0x0 0x00500000 0x0 0x10000>;

--- a/arch/riscv/boot/dts/zhihe/a210.dtsi
+++ b/arch/riscv/boot/dts/zhihe/a210.dtsi
@@ -1175,6 +1175,165 @@
 			clock-names = "pclk";
 		};
 
+		aon_gpio0: gpio@30841000 {
+			compatible = "snps,dw-apb-gpio";
+			reg = <0x00 0x30841000 0x0 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&aon_110m>, <&osc_32k>;
+			clock-names = "bus", "db";
+
+			ao_gpio0: gpio-controller@0 {
+				compatible = "snps,dw-apb-gpio-port";
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <32>;
+				reg = <0>;
+
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupt-parent = <&intc>;
+				interrupts = <17>;
+			};
+		};
+
+		aon_gpio1: gpio@30897000 {
+			compatible = "snps,dw-apb-gpio";
+			reg = <0x00 0x30897000 0x0 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&aon_110m>, <&osc_32k>;
+			clock-names = "bus", "db";
+
+			ao_gpio1: gpio-controller@0 {
+				compatible = "snps,dw-apb-gpio-port";
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <10>;
+				reg = <0>;
+
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupt-parent = <&intc>;
+				interrupts = <10>;
+			};
+		};
+
+		peri1_gpio0: gpio@2012000 {
+			compatible = "snps,dw-apb-gpio";
+			reg = <0x00 0x02012000 0x0 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&clk_peri PERI1_GPIO0_PCLK_EN>,
+				 <&clk_peri PERI1_GPIO0_DBCLK_EN>;
+			clock-names = "bus", "db";
+
+			gpio0: gpio-controller@0 {
+				compatible = "snps,dw-apb-gpio-port";
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <32>;
+				reg = <0>;
+
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupt-parent = <&intc>;
+				interrupts = <289>;
+			};
+		};
+
+		peri1_gpio1: gpio@2013000 {
+			compatible = "snps,dw-apb-gpio";
+			reg = <0x00 0x02013000 0x0 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&clk_peri PERI1_GPIO1_PCLK_EN>,
+				 <&clk_peri PERI1_GPIO1_DBCLK_EN>;
+			clock-names = "bus", "db";
+
+			gpio1: gpio-controller@0 {
+				compatible = "snps,dw-apb-gpio-port";
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <18>;
+				reg = <0>;
+
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupt-parent = <&intc>;
+				interrupts = <290>;
+			};
+		};
+
+		peri2_gpio2: gpio@8410000 {
+			compatible = "snps,dw-apb-gpio";
+			reg = <0x00 0x08410000 0x0 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&clk_peri PERI2_GPIO2_PCLK_EN>,
+				 <&clk_peri PERI2_GPIO2_DBCLK_EN>;
+			clock-names = "bus", "db";
+
+			gpio2: gpio-controller@0 {
+				compatible = "snps,dw-apb-gpio-port";
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <32>;
+				reg = <0>;
+
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupt-parent = <&intc>;
+				interrupts = <291>;
+			};
+		};
+
+		peri2_gpio3: gpio@8412000 {
+			compatible = "snps,dw-apb-gpio";
+			reg = <0x00 0x08412000 0x0 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&clk_peri PERI2_GPIO3_PCLK_EN>,
+				 <&clk_peri PERI2_GPIO3_DBCLK_EN>;
+			clock-names = "bus", "db";
+
+			gpio3: gpio-controller@0 {
+				compatible = "snps,dw-apb-gpio-port";
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <11>;
+				reg = <0>;
+
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupt-parent = <&intc>;
+				interrupts = <292>;
+			};
+		};
+
+		peri3_gpio: gpio@550000 {
+			compatible = "snps,dw-apb-gpio";
+			reg = <0x00 0x00550000 0x0 0x10000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&clk_peri PERI3_GPIO4_PCLK_EN>,
+				 <&clk_peri PERI3_GPIO4_DBCLK_EN>;
+			clock-names = "bus", "db";
+
+			gpio4: gpio-controller@0 {
+				compatible = "snps,dw-apb-gpio-port";
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <6>;
+				reg = <0>;
+
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupt-parent = <&intc>;
+				interrupts = <52>;
+			};
+		};
+
 		mbox_920: mailbox@321000 {
 			compatible = "zhihe,a210-mailbox-v2";
 			reg = <0x00 0x00321000 0x0 0x1000>,

--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -1675,6 +1675,9 @@ static const struct of_device_id dw_dma_of_id_table[] = {
 	}, {
 		.compatible = "xuantie,th1520-axi-dma",
 		.data = (void *)(AXI_DMA_FLAG_USE_CFG2),
+	}, {
+		.compatible = "zhihe,a210-axi-dma",
+		.data = (void *)(AXI_DMA_FLAG_HAS_RESETS | AXI_DMA_FLAG_USE_CFG2),
 	},
 	{}
 };


### PR DESCRIPTION
Add peripheral support for the ZhiHe A210 SoC: GPIO, DW APB timers, I2C, SPI and DMA (dw-axi-dmac) bindings/drivers and device trees.

Tracked by #381.

Note: this branch is stacked on top of the A210 pinctrl/power series (#375). Once #375 is merged and this branch rebased, the diff will narrow down to the 8 peripheral commits:

- dt-bindings: gpio: snps,dw-apb: add ZhiHe A210
- dt-bindings: dma: snps,dw-axi-dmac: add ZhiHe A210
- dmaengine: dw-axi-dmac: add ZhiHe A210 support
- riscv: dts: zhihe: add A210 GPIO controllers
- riscv: dts: zhihe: add A210 DW APB timers
- riscv: dts: zhihe: add A210 I2C controllers
- riscv: dts: zhihe: add A210 SPI controllers
- riscv: dts: zhihe: add A210 DMA controller