### PR TITLE
firmware: thead: th1520_event: make stubs static inline

### DIFF
--- a/include/linux/firmware/thead/th1520_event.h
+++ b/include/linux/firmware/thead/th1520_event.h
@@ -20,11 +20,11 @@ enum th1520_rebootmode_index {
 extern int th1520_event_set_rebootmode(enum th1520_rebootmode_index mode);
 extern int th1520_event_get_rebootmode(enum th1520_rebootmode_index *mode);
 #else
-static int th1520_event_set_rebootmode(enum th1520_rebootmode_index mode)
+static inline int th1520_event_set_rebootmode(enum th1520_rebootmode_index mode)
 {
 	return 0;
 }
-static int th1520_event_get_rebootmode(enum th1520_rebootmode_index *mode)
+static inline int th1520_event_get_rebootmode(enum th1520_rebootmode_index *mode)
 {
 	*mode = TH1520_EVENT_MAX;
 


### PR DESCRIPTION
Fixes: #387 

Change the fallback stubs in th1520_event.h from static to static inline.